### PR TITLE
Fix mpi-test.sh

### DIFF
--- a/test/compilers/mpi-test.sh
+++ b/test/compilers/mpi-test.sh
@@ -11,11 +11,10 @@ echo -n "mpiifort? "
 echo $(which mpiifort)
 echo -n "gfortran? "
 echo $(which gfortran)
-echo -n "ifort?    "
-echo $(which ifort)
 echo -n "ifx?      "
 echo $(which ifx)
 
-mpiifort mpiifort-test.f90 -o build/mpiifort-test
+mpiifort -fc=ifx mpiifort-test.f90 -o build/mpiifort-test
+# or use mpiifx
 
 mpirun -np 2 build/mpiifort-test


### PR DESCRIPTION
Related to #47.

`ifort` has been discontinued, so we need to use `ifx` starting with the 2025.0 release.