### PR TITLE
Let dependabot also check github-actions and pre-commit.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,17 @@
 
 version: 2
 updates:
-  - package-ecosystem: npm
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Since [March](https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/), dependabot is also able to check for updates in the pre-commit ecosystem. I would like to enable this along with checks for the github-actions ecosystem.